### PR TITLE
Add hashing capability for persisted queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 node_modules
-lib
+dist

--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ Generate JS modules that use the ES modules syntax
 
 If `true`, the loader will remove unused fragments from the imported document. This may be useful if a query is importing fragments from a file, but does not use all fragments in that file. Also see [this issue](https://github.com/apollographql/graphql-tag/issues/102).
 
+#### hash _(boolean | "replace") (default=false)_
+
+If `true`, exports an additional constant named `hash` which is a sha256 hash of the query contents. This can be used for [persisted queries](https://www.apollographql.com/docs/apollo-server/performance/apq/).
+
+If `'replace'` is specified, the default export will be replaced with the hash instead of exporting the query. Useful in a production environment if your server is aware of the persisted hashes and you don't want to bundle the queries.
+
+#### hashFunction _(function) (default=defaultHashFunction)_
+
+If using the `hash` option, you can supply a custom hashing function. If not specified, there is a default that uses the built-in node crypto.
+
 ## Import statements in `.graphql` files
 
 The loader supports importing `.graphql` files from other `.graphql` files using an `#import` statement. For example:

--- a/README.md
+++ b/README.md
@@ -67,6 +67,22 @@ If `'replace'` is specified, the default export will be replaced with the hash i
 
 If using the `hash` option, you can supply a custom hashing function. If not specified, there is a default that uses the built-in node crypto.
 
+## Plugin
+
+If you use the `hash` options of the loader for persisted queries, you can optionally also add the companion plugin which will output a json manifest of all the queries with their corresponding hash. You could then use this manifest to prime your server.
+
+```js
+const GraphQLLoaderPlugin = require('@bustle/graphql-loader/plugin')
+module.exports = {
+  // ...
+  plugins: [
+    new GraphQLLoaderPlugin({
+      hashManifestFilename: 'graphql-hash-manifest.json' // Optional filename option. This is the default
+    })
+  ]
+}
+```
+
 ## Import statements in `.graphql` files
 
 The loader supports importing `.graphql` files from other `.graphql` files using an `#import` statement. For example:

--- a/README.md
+++ b/README.md
@@ -53,10 +53,6 @@ Specifies whether or not the imported document should be a printed graphql strin
 
 If `true` and the `output` option is `string`, the loader will strip comments and whitespace from the graphql document strings. This helps to reduce bundled code size.
 
-#### esModule _(boolean) (default=true)_
-
-Generate JS modules that use the ES modules syntax
-
 #### removeUnusedFragments _(boolean) (default=false)_
 
 If `true`, the loader will remove unused fragments from the imported document. This may be useful if a query is importing fragments from a file, but does not use all fragments in that file. Also see [this issue](https://github.com/apollographql/graphql-tag/issues/102).

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ module.exports = {
   // ...
   plugins: [
     new GraphQLLoaderPlugin({
-      hashManifestFilename: 'graphql-hash-manifest.json' // Optional filename option. This is the default
+      manifestFilename: 'graphql-hash-manifest.json' // Optional filename option. This is the default
     })
   ]
 }

--- a/package.json
+++ b/package.json
@@ -3,16 +3,17 @@
   "version": "1.0.0",
   "description": "GraphQL Loader for Webpack",
   "license": "MIT",
-  "main": "./lib/loader.js",
-  "types": "./lib/loader.d.ts",
+  "main": "./dist/index.js",
   "files": [
-    "lib"
+    "dist"
   ],
   "homepage": "https://github.com/bustle/graphql-loader",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/bustle/graphql-loader.git"
-  },
+  "repository": "bustle/graphql-loader",
+  "keywords": [
+    "webpack",
+    "loader",
+    "graphql"
+  ],
   "scripts": {
     "build": "tsc",
     "test": "jest",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,5 @@
+import loader from './loader'
+import GraphQLLoaderPlugin from './plugin'
+
+export default loader
+export { GraphQLLoaderPlugin }

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -206,5 +206,3 @@ function minifyDocumentString(documentString: string): string {
 function defaultHashFunction(documentString: string): string {
   return createHash('sha256').update(documentString).digest('hex')
 }
-
-export { removeDuplicateFragments, removeSourceLocations, removeUnusedFragments } from './transforms'

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,0 +1,32 @@
+import { join } from 'path'
+import { WebpackPluginInstance, Compiler, Compilation, sources } from 'webpack'
+import { hashedQueryMapKey } from './loader'
+
+const PluginName = 'GraphQLLoaderPlugin'
+
+export default class GraphQLLoaderPlugin implements WebpackPluginInstance {
+  apply(compiler: Compiler) {
+    compiler.hooks.compilation.tap(PluginName, (compilation) => {
+      compilation.hooks.processAssets.tap(
+        {
+          name: PluginName,
+          stage: Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
+        },
+        () => {
+          // @ts-ignore
+          const hashedQueryMap = compilation[hashedQueryMapKey] || {}
+          const hashes = Object.keys(hashedQueryMap)
+          if (!hashes.length) return
+
+          const hashedQueryMapSorted = hashes.sort().reduce((sorted, hash) => {
+            sorted[hash] = hashedQueryMap[hash]
+            return sorted
+          }, {} as Record<string, string>)
+
+          const content = JSON.stringify(hashedQueryMapSorted, null, 2)
+          compilation.emitAsset('graphql-hash-manifest.json', new sources.RawSource(content))
+        }
+      )
+    })
+  }
+}

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -4,9 +4,19 @@ import { hashedQueryMapKey } from './loader'
 
 const PluginName = 'GraphQLLoaderPlugin'
 
+interface GraphQLLoaderPluginOptions {
+  hashManifestFilename?: string
+}
+
 export default class GraphQLLoaderPlugin implements WebpackPluginInstance {
+  private hashManifestFilename: string
+
+  constructor(options?: GraphQLLoaderPluginOptions) {
+    this.hashManifestFilename = options?.hashManifestFilename || 'graphql-hash-manifest.json'
+  }
+
   apply(compiler: Compiler) {
-    compiler.hooks.compilation.tap(PluginName, (compilation) => {
+    compiler.hooks.thisCompilation.tap(PluginName, (compilation) => {
       compilation.hooks.processAssets.tap(
         {
           name: PluginName,
@@ -24,7 +34,7 @@ export default class GraphQLLoaderPlugin implements WebpackPluginInstance {
           }, {} as Record<string, string>)
 
           const content = JSON.stringify(hashedQueryMapSorted, null, 2)
-          compilation.emitAsset('graphql-hash-manifest.json', new sources.RawSource(content))
+          compilation.emitAsset(this.hashManifestFilename, new sources.RawSource(content))
         }
       )
     })

--- a/test/__snapshots__/base.spec.ts.snap
+++ b/test/__snapshots__/base.spec.ts.snap
@@ -144,6 +144,20 @@ fragment B on B {
 }
 `;
 
+exports[`graphql-loader hash 1`] = `
+Object {
+  "default": "query X{x y z}",
+  "hash": "0cc86a7ea2ae4bb9587dd06bdc58e17d9c29e14748e703a8e7716736433d2209",
+}
+`;
+
+exports[`graphql-loader hash-replace 1`] = `
+Object {
+  "default": "0cc86a7ea2ae4bb9587dd06bdc58e17d9c29e14748e703a8e7716736433d2209",
+  "hash": "0cc86a7ea2ae4bb9587dd06bdc58e17d9c29e14748e703a8e7716736433d2209",
+}
+`;
+
 exports[`graphql-loader issue-1-import-from-fragment 1`] = `
 Object {
   "default": "{

--- a/test/base.spec.ts
+++ b/test/base.spec.ts
@@ -15,7 +15,9 @@ describe('graphql-loader', function () {
     'filter-unused-fragments',
     'issue-1-import-from-fragment',
     'two-loaders',
-    'minify'
+    'minify',
+    'hash',
+    'hash-replace'
   ].forEach((fixturePath) =>
     it(fixturePath, async function () {
       try {

--- a/test/fixtures/hash-replace/query.graphql
+++ b/test/fixtures/hash-replace/query.graphql
@@ -1,0 +1,5 @@
+query X {
+  x
+  y
+  z
+}

--- a/test/fixtures/hash-replace/webpack.config.ts
+++ b/test/fixtures/hash-replace/webpack.config.ts
@@ -1,0 +1,21 @@
+module.exports = {
+  context: __dirname,
+  entry: './query.graphql',
+  module: {
+    rules: [
+      {
+        test: /\.graphql$/,
+        exclude: /node_modules/,
+        use: [
+          {
+            loader: require.resolve('../../../src/loader'),
+            options: {
+              minify: true,
+              hash: 'replace'
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/fixtures/hash/query.graphql
+++ b/test/fixtures/hash/query.graphql
@@ -1,0 +1,5 @@
+query X {
+  x
+  y
+  z
+}

--- a/test/fixtures/hash/webpack.config.ts
+++ b/test/fixtures/hash/webpack.config.ts
@@ -1,0 +1,21 @@
+module.exports = {
+  context: __dirname,
+  entry: './query.graphql',
+  module: {
+    rules: [
+      {
+        test: /\.graphql$/,
+        exclude: /node_modules/,
+        use: [
+          {
+            loader: require.resolve('../../../src/loader'),
+            options: {
+              minify: true,
+              hash: true
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,10 @@
     "strict": true,
     "declaration": true,
     "noEmitOnError": true,
-    "lib": ["es2020"],
-    "outDir": "lib/"
+    "module": "commonjs",
+    "target": "es2019",
+    "lib": ["es2019"],
+    "outDir": "dist"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src"]
 }


### PR DESCRIPTION
Adds a `hash` option to the loader that will output a sha256 hash constant of the query alongside or as the default export.

Also adds an optional plugin which can output a json manifest of all the queries/hashes.